### PR TITLE
Fix: Removes zero-opacity hover effects on profile link

### DIFF
--- a/src/components/profileMenuDropdown.css
+++ b/src/components/profileMenuDropdown.css
@@ -58,8 +58,11 @@
   letter-spacing: 0.5px;
 }
 .link-to-config:hover {
-  opacity: 0px;
   background: #f1f2f4;
+}
+
+.css-1ty026z {
+  padding: 16px;
 }
 
 .config-wrapper {


### PR DESCRIPTION
Fix: Removes zero-opacity hover effects on profile links;
Also adjusted its padding to 16px.